### PR TITLE
whole_window parameter added to modal function

### DIFF
--- a/R/modal.R
+++ b/R/modal.R
@@ -9,17 +9,15 @@
 #' @examples
 #' modal()
 #' @export
-modal <- function(..., title = NULL, id = NULL){
+modal <- function(..., title = NULL, id = NULL, whole_window = FALSE){
   contents <- rlang::dots_list(...)
-  div(class = "modal", id = id,
+  div(class = "modal", id = id, whole_window = whole_window,
       div(class = "modal-wrapper",
           div(class = "modal-title",
               tags$h3(title),
-              tags$button(style = "background-color: inherit; border: none;", svgX())
-          ),
-          div(class = "modal-content", div(contents))
-      )
-  )
+              tags$button(style = "background-color: inherit; border: none;",
+                          svgX())),
+          div(class = "modal-content", div(contents))))
 }
 
 #' Modal button to trigger a modal

--- a/inst/assets/js/index.js
+++ b/inst/assets/js/index.js
@@ -60,21 +60,21 @@ for (let header of headers) {
 
 $(document).ready(function() {
   Shiny.addCustomMessageHandler('showModalManually', function(modalID) {
-  	var modal = document.getElementById(modalID);
-  	modal.classList.add('is-visible');
-  	modal.addEventListener('click', function(event) {
-  		if (event.target.matches('.modal-title button') || event.target.matches('.modal') || event.target.matches('.modal-title svg') || event.target.matches('.modal-title path')) {
-  			modal.classList.remove('is-visible');
-  		}
-  	});
+    var modal = document.getElementById(modalID);
+    modal.classList.add('is-visible');
+    modal.addEventListener('click', function(event) {
+      if (event.target.matches('.modal-title button') || event.target.matches('.modal') || event.target.matches('.modal-title svg') || event.target.matches('.modal-title path')) {
+        modal.classList.remove('is-visible');
+      }
+    });
   })
 });
 
 $(document).ready(function() {
   Shiny.addCustomMessageHandler('removeModalManually', function(modalID) {
-  	var modal = document.getElementById(modalID);
-  	modal.classList.remove('is-visible');
-  })
+    var modal = document.getElementById(modalID);
+    modal.classList.remove('is-visible');
+  });
 });
 
 $(document).on('shiny:value', function(event) {
@@ -85,16 +85,28 @@ $(document).on('shiny:value', function(event) {
 
   if (modalTriggers) {
     modalTriggers.forEach(function (modalTrigger) {
-      function handleModalTrigger(event) {
-        var modal = document.getElementById(this.dataset.modal);
-        modal.classList.add('is-visible');
-        modal.addEventListener('click', function(event) {
-          if (event.target.matches('.modal-title button') || event.target.matches('.modal') || event.target.matches('.modal-title svg') || event.target.matches('.modal-title path')) {
-            modal.classList.remove('is-visible');
+      // ### con esto no sirve en las apps (quedan dos modales iguales --mismo id)
+        //  var modal_0 = document.getElementById(modalTrigger.dataset.modal)
+        //  if (modal_0.getAttribute("whole_window") === "TRUE") {
+          //    var parent_div = document.querySelector('body div.layout-container');
+          //    parent_div.appendChild(modal_0);
+          //  }
+        function handleModalTrigger(event) {
+          var modal = document.getElementById(this.dataset.modal);
+          var parent = modal.parentElement;
+          // ### con esto sirve pero la transición del modal no se ve en el primer click
+          if (!parent.classList.contains("layout-container") && modal.getAttribute("whole_window") === "TRUE") {
+            var parent_div = document.querySelector('body div.layout-container');
+            parent_div.appendChild(modal);
           }
-        });
-      }
-      modalTrigger.addEventListener('click', handleModalTrigger);
+          modal.classList.add('is-visible');
+          modal.addEventListener('click', function(event) {
+            if (event.target.matches('.modal-title button') || event.target.matches('.modal') || event.target.matches('.modal-title svg') || event.target.matches('.modal-title path')) {
+              modal.classList.remove('is-visible');
+            }
+          });
+        }
+        modalTrigger.addEventListener('click', handleModalTrigger);
     });
   }
 

--- a/man/modal.Rd
+++ b/man/modal.Rd
@@ -4,7 +4,7 @@
 \alias{modal}
 \title{Modal window}
 \usage{
-modal(..., title = NULL, id = NULL)
+modal(..., title = NULL, id = NULL, whole_window = FALSE)
 }
 \arguments{
 \item{...}{html list contents for the panel}


### PR DESCRIPTION
before the modal was rendered within it's closest block container, now, depending on the value of this parameter (TRUE or FALSE) modal can be rendered withing it's closest block container or within the whole window --- in progress (david is going to see if there is a css solution)